### PR TITLE
Update nodeconf logo for 2016

### DIFF
--- a/chapters.json
+++ b/chapters.json
@@ -1,7 +1,7 @@
 [{
   "name": "NodeConf Barcelona",
   "url": "http://barcelona.nodeconf.com",
-  "image": "nodeconf.svg",
+  "image": "nodeconf.png",
   "contact": "nodeconf@barcelonajs.org"
 },{
   "name": "Barcelona Nodeschool",


### PR DESCRIPTION
The current SVG logo didn't fit, in size, very well, so I used the png version to publish the update of barcelonajs.org site.

I didn't have any tool at the moment of the update to modify the SVG, if we want to use that format, then we could update it in the site repo and not to merge this PR.